### PR TITLE
Replace rgl.* with *3d

### DIFF
--- a/R/plotReponseSurface.R
+++ b/R/plotReponseSurface.R
@@ -286,7 +286,7 @@ plotResponseSurface <- function(data, fitResult = NULL,
   if (!add){
     ## Add box and annotation
     ## Must come after persp3d, otherwise only get wireframe
-    rgl.bbox(xlen = 0, ylen = 0, zlen = 0, # no tickmarks
+    bbox3d(xlen = 0, ylen = 0, zlen = 0, # no tickmarks
              expand = 1.03,
              color = "#000000", front = "lines", back = "cull")
     axis3d(edge = "x--", at = xat, labels = format(xlab, ...))

--- a/inst/ui/server.R
+++ b/inst/ui/server.R
@@ -174,7 +174,7 @@ shinyServer(function(input, output, session) {
                           plotfun = median,
                           colorPalette = c("#EFF3FF", "#BDD7E7", "#6BAED6", "#2171B5"))
       scene1 <- scene3d()
-      rgl.close()
+      close3d()
       rglwidget(scene1)
     })
 

--- a/tests/testthat/test_wrapper.R
+++ b/tests/testthat/test_wrapper.R
@@ -65,17 +65,17 @@ test_that("plots", {
       
       expect_silent({
             plot(rs, "maxR")
-            rgl.close()
+            close3d()
           })
 
       expect_silent({
         plot(rs, "confInt")
-        rgl.close()
+        close3d()
       })
 
       expect_silent({
         plot(rs, "z-score")
-        rgl.close()
+        close3d()
       })
     })
 


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to BIGL.  I will be deprecating a number of rgl.* function calls.  You can read about the issues here:

      https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required changes to BIGL in the attached patch. These changes should work with both old and new rgl versions.